### PR TITLE
Add dashboard command tester

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,7 @@
 import renderDashboard from "@/dashboard/render-dashboard";
+import renderCommandPage from "@/dashboard/command-page";
 import { setupLoggerOnce } from "@/services/logger";
+import { commandRouter } from "@/initialize";
 import type { BunRequest } from "bun";
 
 
@@ -58,6 +60,31 @@ Bun.serve({
                         "Location": "/dashboard"
                     }
                 });
+            }
+        },
+        "/dashboard/command": {
+            async GET(req: BunRequest) {
+                return await renderCommandPage(req);
+            },
+            async POST(req: BunRequest) {
+                if (req.cookies.get("DASH_COOKIE") !== process.env.DASHBOARD_KEY) {
+                    return new Response(null, {
+                        status: 401
+                    });
+                }
+
+                const formData = await req.formData();
+                const command = formData.get("command")?.toString() ?? "";
+
+                const result = await commandRouter.handleAndGetResult({
+                    sender: "0000",
+                    message: command,
+                    group: false,
+                    number: "0000",
+                    name: "Dashboard"
+                });
+
+                return Response.json({ result: result ?? "" });
             }
         }
     },

--- a/src/dashboard/command-page.tsx
+++ b/src/dashboard/command-page.tsx
@@ -1,0 +1,45 @@
+import { renderToReadableStream } from "react-dom/server";
+import DashboardShell from "./shell";
+import renderLoginPage from "./login";
+
+export default async function renderCommandPage(req: Bun.BunRequest) {
+    if (req.cookies.get("DASH_COOKIE") !== process.env.DASHBOARD_KEY) {
+        return await renderLoginPage();
+    }
+
+    return new Response(
+        await renderToReadableStream(
+            <DashboardShell>
+                <div className="min-h-screen bg-gray-50 p-6">
+                    <div className="max-w-xl mx-auto space-y-4">
+                        <h1 className="text-2xl font-bold text-gray-900">Command Tester</h1>
+                        <form id="command-form" className="flex gap-2">
+                            <input id="command-input" type="text" className="flex-1 border rounded px-3 py-2" placeholder="Enter command" />
+                            <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">Run</button>
+                        </form>
+                        <pre id="command-output" className="bg-gray-100 p-4 rounded text-sm whitespace-pre-wrap"></pre>
+                    </div>
+                </div>
+
+                <script dangerouslySetInnerHTML={{
+                    __html: `
+                        document.getElementById('command-form').addEventListener('submit', async function(e) {
+                            e.preventDefault();
+                            const input = (document.getElementById('command-input') as HTMLInputElement).value;
+                            const formData = new FormData();
+                            formData.append('command', input);
+                            const res = await fetch('/dashboard/command', { method: 'POST', body: formData });
+                            const data = await res.json();
+                            document.getElementById('command-output').textContent = data.result || 'No response';
+                        });
+                    `
+                }} />
+            </DashboardShell>
+        ),
+        {
+            headers: {
+                'Content-Type': 'text/html; charset=utf-8'
+            }
+        }
+    );
+}

--- a/src/dashboard/login.tsx
+++ b/src/dashboard/login.tsx
@@ -1,0 +1,44 @@
+import { renderToReadableStream } from "react-dom/server";
+import DashboardShell from "./shell";
+
+export default async function renderLoginPage() {
+    return new Response(
+        await renderToReadableStream(
+            <DashboardShell>
+                <div className="min-h-screen bg-gray-100 flex items-center justify-center p-4">
+                    <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-8">
+                        <div className="text-center mb-8">
+                            <h2 className="text-2xl font-bold text-gray-900">Dashboard Login</h2>
+                            <p className="text-gray-600">Please enter your dashboard key to continue</p>
+                        </div>
+                        <form method="POST" className="space-y-6">
+                            <div>
+                                <label htmlFor="key" className="block text-sm font-medium text-gray-700">
+                                    Dashboard Key
+                                </label>
+                                <input
+                                    type="password"
+                                    name="key"
+                                    id="key"
+                                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                                    required
+                                />
+                            </div>
+                            <button
+                                type="submit"
+                                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                            >
+                                Sign in
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </DashboardShell>
+        ),
+        {
+            headers: {
+                'Content-Type': 'text/html; charset=utf-8'
+            }
+        }
+    );
+}

--- a/src/dashboard/render-dashboard.tsx
+++ b/src/dashboard/render-dashboard.tsx
@@ -1,49 +1,8 @@
 import { renderToReadableStream } from "react-dom/server"
 import DashboardShell from "./shell"
 import DashboardError from "./error"
+import renderLoginPage from "./login"
 import { ALLOWED_GROUPS, rateLimiter, commandRouter, whatsapp } from "@/initialize";
-
-async function renderLoginPage() {
-    return new Response(
-        await renderToReadableStream(
-            <DashboardShell>
-                <div className="min-h-screen bg-gray-100 flex items-center justify-center p-4">
-                    <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-8">
-                        <div className="text-center mb-8">
-                            <h2 className="text-2xl font-bold text-gray-900">Dashboard Login</h2>
-                            <p className="text-gray-600">Please enter your dashboard key to continue</p>
-                        </div>
-                        <form method="POST" className="space-y-6">
-                            <div>
-                                <label htmlFor="key" className="block text-sm font-medium text-gray-700">
-                                    Dashboard Key
-                                </label>
-                                <input
-                                    type="password"
-                                    name="key"
-                                    id="key"
-                                    className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                                    required
-                                />
-                            </div>
-                            <button
-                                type="submit"
-                                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-                            >
-                                Sign in
-                            </button>
-                        </form>
-                    </div>
-                </div>
-            </DashboardShell>
-        ),
-        {
-            headers: {
-                'Content-Type': 'text/html; charset=utf-8'
-            }
-        }
-    );
-}
 
 
 export default async function renderDashboard(req: Bun.BunRequest) {
@@ -240,8 +199,9 @@ export default async function renderDashboard(req: Bun.BunRequest) {
                                         </div>
                                     </div>
                                 </div>
-                            </div>
                         </div>
+                    </div>
+
 
                         {/* Real-time Activity Log */}
                         <div className="mt-8">
@@ -343,6 +303,7 @@ export default async function renderDashboard(req: Bun.BunRequest) {
                             logCount = 0;
                             document.getElementById('log-count').textContent = '0 messages';
                         });
+
 
                         // Start SSE connection when page loads
                         connectSSE();


### PR DESCRIPTION
## Summary
- allow command tests from dashboard using new `/dashboard/command` route
- extract login page component
- move command test UI to a new page

## Testing
- `bun run index.ts` *(fails: Cannot find module 'react/jsx-dev-runtime')*

------
https://chatgpt.com/codex/tasks/task_e_68405b34a904832f8cd2a2597fde990d